### PR TITLE
Support `construct` and `extern` keywords

### DIFF
--- a/grammars/vala.cson
+++ b/grammars/vala.cson
@@ -615,7 +615,7 @@
       '1':
         'name': 'storage.modifier.vala'
     'comment': 'Not sure about unsafe and readonly'
-    'match': '\\b(public|private|protected|internal|static|final|sealed|virtual|override|abstract|readonly|volatile|dynamic|async|unsafe|out|ref|weak|owned|unowned|const)\\b'
+    'match': '\\b(public|private|protected|internal|static|final|sealed|virtual|override|abstract|readonly|volatile|dynamic|async|unsafe|out|ref|weak|owned|unowned|const|extern)\\b'
   'strings':
     'patterns': [
       {

--- a/grammars/vala.cson
+++ b/grammars/vala.cson
@@ -159,7 +159,7 @@
       }
     ]
   'class':
-    'begin': '(?=\\w?[\\w\\s]*(?:class|(?:@)?interface|enum|errordomain|struct|namespace)\\s+\\w+)'
+    'begin': '(?=\\w?[\\w\\s]*\\b(?:class|(?:@)?interface|enum|errordomain|struct|namespace)\\s+\\w+)'
     'comment': 'attempting to put namespace in here.'
     'end': '}'
     'endCaptures':
@@ -386,7 +386,7 @@
         'name': 'keyword.control.vala'
       }
       {
-        'match': '\\b(return|break|case|continue|default|do|while|for|foreach|switch|if|else|in|yield|get|set|value)\\b'
+        'match': '\\b(return|break|case|continue|default|do|while|for|foreach|switch|if|else|in|yield|get|set|value|construct)\\b'
         'name': 'keyword.control.vala'
       }
       {


### PR DESCRIPTION
This adds both the `extern` storage modifier and the `construct` keyword used in properties.

Sample code for `extern`:

``` Vala
[CCode(cname="GETTEXT_PACKAGE")] extern const string GETTEXT_PACKAGE;
```

Sample code for `construct` (a property which can only be set inside the constructor):

``` Vala
class MyClass {
  public string my_property { get; construct set; }
}
```

Especially the `construct` keyword got rendered very ugly (just like Github does it here).
